### PR TITLE
:lipstick: Make access easier to the companies' link

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 /*
-tailwind has been added by defualt from latest version of nextjs but we might use it but not now.
+tailwind has been added by default from latest version of nextjs but we might use it but not now.
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -81,6 +81,16 @@ select {
   border: none;
   padding: 0 5px 0 5px;
   color: rgb(37, 37, 37);
+}
+
+.icon {
+  vertical-align: top;
+  margin: 0.25rem;
+}
+
+.link {
+  display: inline-block;
+  width: 100%;
 }
 
 .no-data {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,6 +106,7 @@ export default function Home() {
         <table>
           <tbody>
             <tr>
+              <th>Jobs</th>
               <SortableHeader
                 title="name"
                 isActive={sortByColumn === "name"}
@@ -128,7 +129,6 @@ export default function Home() {
                 isActive={sortByColumn === "industry"}
                 onSortTypeChange={handleSortByColumn}
               />
-              <th>Jobs</th>
             </tr>
             {companies.map((company: Company) => {
               return (
@@ -136,27 +136,34 @@ export default function Home() {
                   key={company.name}
                   className="odd:bg-white even:bg-slate-50"
                 >
-                  <td>{company.name}</td>
+                  <td>
+                    <a
+                        href={company.linkedin}
+                        className="text-center"
+                        target="_blank"
+                    >
+                      <Image
+                          src="./linkedin.png"
+                          width={16}
+                          height={16}
+                          alt={`LinkedIn job page for ${company.name} company.`}
+                      />
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      href={company.linkedin}
+                      target="_blank"
+                    >
+                      {company.name}
+                    </a>
+                  </td>
                   <td>{company.country}</td>
                   <td>{company.city}</td>
                   <td className="hidden-on-mobile">
                     {company.numberOfEmployees}
                   </td>
                   <td className="hidden-on-mobile">{company.industry}</td>
-                  <td>
-                    <a
-                      href={company.linkedin}
-                      className="text-center"
-                      target="_blank"
-                    >
-                      <Image
-                        src="./linkedin.png"
-                        width={16}
-                        height={16}
-                        alt={`LinkedIn job page for ${company.name} company.`}
-                      />
-                    </a>
-                  </td>
                 </tr>
               );
             })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,7 +106,6 @@ export default function Home() {
         <table>
           <tbody>
             <tr>
-              <th>Jobs</th>
               <SortableHeader
                 title="name"
                 isActive={sortByColumn === "name"}
@@ -138,24 +137,18 @@ export default function Home() {
                 >
                   <td>
                     <a
-                        href={company.linkedin}
-                        className="text-center"
-                        target="_blank"
+                      href={company.linkedin}
+                      target="_blank"
+                      className={"link"}
                     >
                       <Image
                           src="./linkedin.png"
                           width={16}
                           height={16}
                           alt={`LinkedIn job page for ${company.name} company.`}
+                          className={"icon"}
                       />
-                    </a>
-                  </td>
-                  <td>
-                    <a
-                      href={company.linkedin}
-                      target="_blank"
-                    >
-                      {company.name}
+                      <span className="align-middle">{company.name}</span>
                     </a>
                   </td>
                   <td>{company.country}</td>


### PR DESCRIPTION
- Move the Jobs column left next to the Name column
- Convert companies' name from plain text to hyperlink

Changes preview:
![image](https://github.com/SiaExplains/visa-sponsorship-companies/assets/2290912/9ea0c593-7a0e-4279-a087-710e30c8acc6)
